### PR TITLE
Drop lightning upper bound

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: '{{ PYTHON }} -m pip install . -vv '
 
 requirements:
@@ -28,7 +28,7 @@ requirements:
     - openpyxl >=3.0
     - pandas >=1.0
     - pyro-ppl >=1.6.0
-    - lightning >=2.0,<2.1
+    - lightning >=2.0
     - rich >=12.0.0
     - scikit-learn >=0.21.2
     - pytorch >=1.8.0


### PR DESCRIPTION
This increments the build number to 1, which should be reset to 0 upon new version release @canergen